### PR TITLE
docs(roadmap): Add Terraform workspaces implementation roadmap

### DIFF
--- a/roadmap/ROADMAP.md
+++ b/roadmap/ROADMAP.md
@@ -1,13 +1,13 @@
 # Project Roadmap Overview
 
 **Last Updated**: Auto-generated from roadmap items
-**Overall Completion**: 46% (3.64 of 8 items complete)
+**Overall Completion**: 40% (3.64 of 9 items complete)
 
 ## Status Summary
-- 🔴 Planning: 2 items (0% avg)
+- 🔴 Planning: 3 items (0% avg)
 - 🟡 In Progress: 4 items (49% avg)
 - 🟢 Complete: 2 items (100%)
-- 📝 Total: 8 items
+- 📝 Total: 9 items
 
 ## Roadmap Items
 
@@ -16,6 +16,7 @@
 | [Frontend Critical Fixes](in_progress/frontend-critical-fixes/PROGRESS_TRACKER.md) | 🟡 | 57% | [████████████░░░░░░░░] | Critical | 4/7 PRs | `in_progress/` |
 | [AI Contributions](planning/ai-contributions/PROGRESS_TRACKER.md) | 🔴 | 0% | [░░░░░░░░░░░░░░░░░░░░] | High | 0/6 PRs | `planning/` |
 | [Example API Feature](planning/example-api-feature/PROGRESS_TRACKER.md) | 🔴 | 0% | [░░░░░░░░░░░░░░░░░░░░] | Medium | 0/6 PRs | `planning/` |
+| [Terraform Workspaces](planning/terraform-workspaces/PROGRESS_TRACKER.md) | 🔴 | 0% | [░░░░░░░░░░░░░░░░░░░░] | High | 0/6 PRs | `planning/` |
 | [Docker Linting Separation](in_progress/docker-linting-separation/PROGRESS_TRACKER.md) | 🟡 | 75% | [███████████████░░░░░] | High | 18/24 tasks | `in_progress/` |
 | [Docker Reorganization](in_progress/docker-reorganization/PROGRESS_TRACKER.md) | 🟡 | 80% | [████████████████░░░░] | High | 4/5 PRs | `in_progress/` |
 | [Deployment](in_progress/deployment/PROGRESS_TRACKER.md) | 🟡 | 45% | [█████████░░░░░░░░░░░] | Critical | 5/11 PRs | `in_progress/` |
@@ -34,14 +35,14 @@ Items are automatically organized by completion percentage:
 
 ### By Status
 ```
-Planning    [░░░░░░░░░░] 0%   (2 items)
+Planning    [░░░░░░░░░░] 0%   (3 items)
 In Progress [█████░░░░░] 49%  (4 items)
 Complete    [██████████] 100% (2 items)
 ```
 
 ### Overall Project Progress
 ```
-[█████████░░░░░░░░░░░] 46% Complete
+[████████░░░░░░░░░░░░] 40% Complete
 ```
 
 ## Priority Matrix
@@ -52,8 +53,9 @@ Complete    [██████████] 100% (2 items)
 
 ### 🟠 High Priority
 1. **AI Contributions** - 0% - AI workflow improvements planned
-2. **Docker Linting Separation** - 75% - Tasks 1-4 complete, documentation remaining
-3. **Docker Reorganization** - 80% - PR1, PR2, PR3+PR4 complete (compose files moved, all references updated)
+2. **Terraform Workspaces** - 0% - Separate base/runtime infrastructure with workspaces
+3. **Docker Linting Separation** - 75% - Tasks 1-4 complete, documentation remaining
+4. **Docker Reorganization** - 80% - PR1, PR2, PR3+PR4 complete (compose files moved, all references updated)
 
 ### 🟡 Medium Priority
 1. **Example API Feature** - 0% - Template for new features

--- a/roadmap/planning/terraform-workspaces/AI_CONTEXT.md
+++ b/roadmap/planning/terraform-workspaces/AI_CONTEXT.md
@@ -1,0 +1,294 @@
+# Terraform Workspaces Implementation - AI Context
+
+## 🎯 Feature Vision
+
+### Problem Statement
+The current Terraform infrastructure uses a single state file with conditional `count` logic to separate base (persistent) and runtime (ephemeral) resources. This approach causes "empty tuple" errors when trying to destroy only runtime resources because:
+- Runtime resources reference base resources using `[0]` index
+- When `deployment_scope=runtime`, base resources have `count = 0`
+- Terraform can't resolve references to non-existent resources
+
+### Solution Overview
+Implement Terraform workspaces to cleanly separate base and runtime infrastructure:
+- **Base Workspace**: VPC, NAT Gateways, ECR repositories, Route53 zones
+- **Runtime Workspace**: ECS services, ALB listeners, target groups
+- **Data Sources**: Runtime workspace references base resources via data lookups
+
+## 🏗️ Current Architecture
+
+### Existing Structure
+```
+infra/terraform/
+├── resource-scopes.tf    # Defines scope logic
+├── networking.tf         # VPC, subnets (base)
+├── ecr.tf               # Container registries (base)
+├── ecs.tf               # ECS services (runtime)
+├── alb.tf               # Load balancer (mixed)
+└── variables.tf         # Shared variables
+```
+
+### Current Scope Logic
+```hcl
+# resource-scopes.tf
+locals {
+  create_base_resources = var.deployment_scope == "base" || var.deployment_scope == "all"
+  create_runtime_resources = var.deployment_scope == "runtime" || var.deployment_scope == "all"
+}
+
+# Problem: Runtime resources can't reference base when count = 0
+resource "aws_lb_target_group" "frontend" {
+  count = local.should_create_resource.alb_target_groups ? 1 : 0
+  vpc_id = aws_vpc.main[0].id  # Fails when vpc has count = 0
+}
+```
+
+## 🎯 Target Architecture
+
+### Workspace Structure
+```
+infra/terraform/
+├── workspaces/
+│   ├── base/
+│   │   ├── main.tf         # Base resources only
+│   │   ├── outputs.tf      # Expose IDs for runtime
+│   │   └── variables.tf    # Base-specific vars
+│   └── runtime/
+│       ├── main.tf         # Runtime resources only
+│       ├── data.tf         # Lookup base resources
+│       └── variables.tf    # Runtime-specific vars
+├── modules/               # Shared modules if needed
+└── shared/               # Shared configurations
+```
+
+### Workspace Separation
+**Base Workspace** (`terraform workspace select base`):
+- VPC and networking
+- NAT Gateways
+- Security groups
+- ECR repositories
+- Route53 zones
+- ACM certificates
+- ALB (the load balancer itself)
+
+**Runtime Workspace** (`terraform workspace select runtime`):
+- ECS cluster
+- ECS task definitions
+- ECS services
+- ALB target groups
+- ALB listeners
+- Service discovery
+- CloudWatch logs
+
+### Data Source Pattern
+```hcl
+# runtime/data.tf
+data "aws_vpc" "main" {
+  filter {
+    name = "tag:Name"
+    values = ["${var.project_name}-${var.environment}-vpc"]
+  }
+}
+
+# runtime/main.tf
+resource "aws_lb_target_group" "frontend" {
+  vpc_id = data.aws_vpc.main.id  # Always works
+}
+```
+
+## 🔧 Implementation Strategy
+
+### Phase 1: Foundation (PR1)
+- Create workspace directory structure
+- Configure separate backend state paths
+- Set up workspace management scripts
+
+### Phase 2: Resource Separation (PR2-3)
+- Move base resources to base workspace
+- Move runtime resources to runtime workspace
+- Maintain backward compatibility during transition
+
+### Phase 3: Cross-Workspace References (PR4)
+- Implement data sources in runtime workspace
+- Create outputs in base workspace
+- Test dependency resolution
+
+### Phase 4: Operational Integration (PR5)
+- Update Makefile commands
+- Create workspace-aware deployment scripts
+- Add safety checks and validations
+
+### Phase 5: Documentation (PR6)
+- Migration guide for existing infrastructure
+- Operational runbooks
+- Troubleshooting guides
+
+## 🎨 Design Decisions
+
+### Why Workspaces Over Modules?
+- **Clean State Separation**: Each workspace has independent state
+- **Selective Operations**: Can destroy runtime without touching base
+- **Cost Optimization**: Destroy expensive runtime resources nightly
+- **Safety**: Harder to accidentally destroy base infrastructure
+
+### Why Not Separate Repositories?
+- **Complexity**: Would require separate CI/CD pipelines
+- **Versioning**: Harder to keep base/runtime in sync
+- **Development**: More overhead for local development
+
+### Workspace Naming Convention
+- `base-{environment}`: e.g., `base-dev`, `base-prod`
+- `runtime-{environment}`: e.g., `runtime-dev`, `runtime-prod`
+- Default workspace unused to prevent accidents
+
+## 🔐 Security Considerations
+
+### State File Security
+- Separate state files per workspace
+- Different access patterns possible
+- Base state more restricted than runtime
+
+### Resource Access
+- Base resources tagged with workspace
+- Runtime can only read base via data sources
+- No direct modification across workspaces
+
+### Operational Security
+- Separate IAM roles per workspace (optional)
+- Audit trail via CloudTrail
+- Workspace operations logged
+
+## 💰 Cost Optimization Benefits
+
+### Current Costs (Estimated)
+- NAT Gateways: ~$90/month (always running)
+- ALB: ~$20/month (always running)
+- ECS/Fargate: ~$30/month (when running)
+- Total: ~$140/month
+
+### With Workspaces
+- Base (always on): ~$110/month
+- Runtime (12 hours/day): ~$15/month
+- Total: ~$125/month
+- **Savings: ~$15/month (11%)**
+
+### Shutdown Strategy
+```bash
+# Nightly shutdown (cron)
+make infra-down-runtime ENV=dev
+
+# Morning startup
+make infra-up-runtime ENV=dev
+```
+
+## 🚀 Migration Strategy
+
+### Step 1: Prepare
+1. Backup current state
+2. Document existing resources
+3. Test in dev environment first
+
+### Step 2: Create Base Workspace
+1. Import existing base resources
+2. Verify state integrity
+3. Test operations
+
+### Step 3: Create Runtime Workspace
+1. Import existing runtime resources
+2. Update references to use data sources
+3. Test deployments
+
+### Step 4: Cutover
+1. Final state backup
+2. Switch to workspace-based operations
+3. Monitor for issues
+
+## 📊 Success Metrics
+
+### Technical Success
+- ✅ Zero "empty tuple" errors
+- ✅ Clean destroy operations per scope
+- ✅ Faster deployment times
+- ✅ Reduced blast radius for changes
+
+### Operational Success
+- ✅ Simplified runbooks
+- ✅ Clear separation of concerns
+- ✅ Easier troubleshooting
+- ✅ Better cost tracking
+
+## ⚠️ Potential Challenges
+
+### State Migration
+- **Risk**: Corrupted state during migration
+- **Mitigation**: Comprehensive backups, test in dev
+
+### Workspace Confusion
+- **Risk**: Operators unsure which workspace they're in
+- **Mitigation**: Clear prompts, status commands
+
+### Increased Complexity
+- **Risk**: More complex than single state
+- **Mitigation**: Strong documentation, automation
+
+## 🤖 AI Agent Guidance
+
+### Key Principles
+1. **Always Check Workspace**: Before any operation
+2. **Never Mix Resources**: Keep separation clean
+3. **Use Data Sources**: Don't hardcode cross-workspace values
+4. **Tag Everything**: Include workspace in resource tags
+5. **Document Changes**: Update runbooks immediately
+
+### Common Patterns
+```hcl
+# Check workspace
+output "current_workspace" {
+  value = terraform.workspace
+}
+
+# Conditional resources
+count = terraform.workspace == "runtime" ? 1 : 0
+
+# Workspace-specific naming
+name = "${var.project_name}-${terraform.workspace}-${var.environment}"
+```
+
+### Testing Approach
+1. Deploy base workspace
+2. Verify base resources
+3. Deploy runtime workspace
+4. Verify runtime can reference base
+5. Destroy runtime
+6. Verify base intact
+7. Redeploy runtime
+8. Verify functionality restored
+
+## 📚 Reference Documentation
+
+### Terraform Resources
+- [Workspace Documentation](https://www.terraform.io/docs/language/state/workspaces.html)
+- [Data Sources](https://www.terraform.io/docs/language/data-sources/index.html)
+- [State Management](https://www.terraform.io/docs/language/state/index.html)
+
+### AWS Best Practices
+- [Multi-Account Strategy](https://aws.amazon.com/organizations/getting-started/best-practices/)
+- [Infrastructure as Code](https://docs.aws.amazon.com/whitepapers/latest/introduction-devops-aws/infrastructure-as-code.html)
+
+### Internal Context
+- Current infrastructure costs: See AWS Cost Explorer
+- Existing resource IDs: Check Terraform state
+- Deployment frequency: ~5-10 times per day in dev
+
+## 🎯 Definition of Done
+
+The feature is complete when:
+1. All resources separated into appropriate workspaces
+2. Zero errors during scoped destroy operations
+3. Makefile commands updated and tested
+4. Documentation complete and reviewed
+5. Migration completed in dev environment
+6. Runbooks updated for operations team
+7. Cost optimization verified working
+
+---
+**Remember**: This is a high-impact infrastructure change. Test thoroughly in dev before touching production. The goal is zero downtime and improved operational efficiency.

--- a/roadmap/planning/terraform-workspaces/PROGRESS_TRACKER.md
+++ b/roadmap/planning/terraform-workspaces/PROGRESS_TRACKER.md
@@ -1,0 +1,169 @@
+# Terraform Workspaces Implementation - Progress Tracker
+
+## 🎯 Document Purpose
+This is the **PRIMARY HANDOFF DOCUMENT** for implementing Terraform workspaces to separate base and runtime infrastructure. Any AI agent picking up this work should start here to understand current progress and next steps.
+
+## 📊 Current Status
+- **Phase**: Planning Phase
+- **Overall Progress**: [░░░░░░░░░░░░░░░░░░░░] 0%
+- **Current PR**: Not Started
+- **Blocked By**: None
+- **Priority**: High
+- **Complexity**: High
+
+## 📁 Required Documents Location
+All documentation for this roadmap item is in: `roadmap/planning/terraform-workspaces/`
+- `PROGRESS_TRACKER.md` (this file) - Primary handoff and status
+- `AI_CONTEXT.md` - Background and architectural decisions
+- `PR_BREAKDOWN.md` - Detailed implementation steps
+
+## 🚀 Next PR to Implement
+**PR1: Terraform Workspace Foundation**
+- Branch: `feat/terraform-workspaces-pr1-foundation`
+- Start by reading AI_CONTEXT.md for background
+- Then follow PR1 steps in PR_BREAKDOWN.md
+
+## 📈 PR Status Dashboard
+
+| PR # | Title | Status | Branch | Completion |
+|------|-------|--------|--------|------------|
+| PR1 | Terraform Workspace Foundation | 🔴 Not Started | `feat/terraform-workspaces-pr1-foundation` | 0% |
+| PR2 | Base Infrastructure Workspace | 🔴 Not Started | `feat/terraform-workspaces-pr2-base` | 0% |
+| PR3 | Runtime Infrastructure Workspace | 🔴 Not Started | `feat/terraform-workspaces-pr3-runtime` | 0% |
+| PR4 | Data Sources and Cross-Workspace References | 🔴 Not Started | `feat/terraform-workspaces-pr4-data-sources` | 0% |
+| PR5 | Makefile Integration and Commands | 🔴 Not Started | `feat/terraform-workspaces-pr5-makefile` | 0% |
+| PR6 | Documentation and Testing | 🔴 Not Started | `feat/terraform-workspaces-pr6-docs` | 0% |
+
+**Status Legend:**
+- 🔴 Not Started
+- 🟡 In Progress
+- 🟢 Complete
+- 🔵 Blocked
+
+## ✅ Detailed PR Checklists
+
+### PR1: Terraform Workspace Foundation
+**Purpose**: Set up workspace configuration and backend separation
+- [ ] Create workspace configuration file structure
+- [ ] Set up separate state files for base and runtime
+- [ ] Configure backend for workspace isolation
+- [ ] Add workspace selection logic
+- [ ] Create workspace initialization scripts
+- [ ] Test workspace switching
+- [ ] Update terraform init process
+- [ ] Document workspace architecture
+
+### PR2: Base Infrastructure Workspace
+**Purpose**: Isolate base/persistent infrastructure in dedicated workspace
+- [ ] Move base resources to base workspace configuration
+- [ ] Create base.tfvars for base-specific variables
+- [ ] Configure outputs for cross-workspace data sharing
+- [ ] Update resource naming to include workspace
+- [ ] Test base infrastructure deployment
+- [ ] Verify resource tagging
+- [ ] Create base workspace deployment script
+- [ ] Document base resources scope
+
+### PR3: Runtime Infrastructure Workspace
+**Purpose**: Isolate runtime/ephemeral infrastructure in dedicated workspace
+- [ ] Move runtime resources to runtime workspace configuration
+- [ ] Create runtime.tfvars for runtime-specific variables
+- [ ] Remove direct references to base resources
+- [ ] Configure workspace-specific resource counts
+- [ ] Test runtime infrastructure deployment
+- [ ] Verify runtime resource isolation
+- [ ] Create runtime workspace deployment script
+- [ ] Document runtime resources scope
+
+### PR4: Data Sources and Cross-Workspace References
+**Purpose**: Enable runtime workspace to reference base resources
+- [ ] Create data sources for VPC lookup
+- [ ] Create data sources for subnet lookup
+- [ ] Create data sources for security group lookup
+- [ ] Create data sources for ECR repository lookup
+- [ ] Create data sources for Route53 zone lookup
+- [ ] Add conditional logic for data source usage
+- [ ] Test cross-workspace references
+- [ ] Document data source patterns
+
+### PR5: Makefile Integration and Commands
+**Purpose**: Update build system for workspace-aware operations
+- [ ] Update infra-init for workspace selection
+- [ ] Create infra-workspace-list command
+- [ ] Create infra-workspace-select command
+- [ ] Update infra-up for workspace awareness
+- [ ] Update infra-down for workspace awareness
+- [ ] Add workspace status commands
+- [ ] Create workspace migration commands
+- [ ] Test all makefile targets with workspaces
+
+### PR6: Documentation and Testing
+**Purpose**: Complete documentation and validation
+- [ ] Create workspace migration guide
+- [ ] Document workspace architecture decisions
+- [ ] Create runbook for workspace operations
+- [ ] Test full deployment from scratch
+- [ ] Test destroy operations per workspace
+- [ ] Validate cost optimization works
+- [ ] Create troubleshooting guide
+- [ ] Update main infrastructure README
+
+## 🔄 Update Protocol
+
+### After Completing Each PR:
+1. Update PR status in dashboard to 🟢 Complete
+2. Calculate new overall progress: `(Completed PRs / 6) × 100`
+3. Update progress bar visualization
+4. Move "Next PR" pointer to next item
+5. Document any deviations in change log
+6. If progress > 0%, move from `planning/` to `in_progress/`
+7. If progress = 100%, move to `complete/`
+8. Update master ROADMAP.md
+
+### When Blocked:
+1. Update PR status to 🔵 Blocked
+2. Document blocker in "Blocked By" section
+3. Add resolution steps
+4. Note dependencies
+
+## 📝 Change Log
+
+### Planning Phase
+- Created initial roadmap structure
+- Identified 6 PRs for complete implementation
+- Defined workspace separation strategy
+
+## 🎯 Success Criteria
+
+The implementation is complete when:
+- ✅ Base and runtime infrastructure are in separate workspaces
+- ✅ Each workspace has independent state
+- ✅ Runtime can reference base resources via data sources
+- ✅ Destroy operations work correctly per scope
+- ✅ Cost optimization goals are maintained
+- ✅ All makefile commands are workspace-aware
+- ✅ Documentation is complete
+
+## 🚨 Risk Mitigation
+
+### Identified Risks:
+1. **State Migration**: Existing infrastructure needs careful migration
+   - Mitigation: Create backup, test in dev first
+2. **Cross-Workspace Dependencies**: Complex reference patterns
+   - Mitigation: Comprehensive data source layer
+3. **Operational Complexity**: More complex than current setup
+   - Mitigation: Strong documentation and automation
+
+## 📋 Handoff Checklist
+
+When picking up this work:
+- [ ] Read this PROGRESS_TRACKER.md completely
+- [ ] Review AI_CONTEXT.md for background
+- [ ] Check PR_BREAKDOWN.md for implementation details
+- [ ] Verify current infrastructure state
+- [ ] Check for any recent Terraform changes
+- [ ] Create feature branch for next PR
+- [ ] Update this tracker when starting work
+
+---
+**Remember**: Keep this document updated after each PR completion. It's the primary communication tool between AI agents and humans working on this feature.

--- a/roadmap/planning/terraform-workspaces/PR_BREAKDOWN.md
+++ b/roadmap/planning/terraform-workspaces/PR_BREAKDOWN.md
@@ -1,0 +1,737 @@
+# Terraform Workspaces Implementation - PR Breakdown
+
+## PR1: Terraform Workspace Foundation
+
+### Branch: `feat/terraform-workspaces-pr1-foundation`
+
+### Files to Create/Modify:
+1. `infra/terraform/workspaces/README.md`
+2. `infra/terraform/backend-config/base-dev.hcl`
+3. `infra/terraform/backend-config/runtime-dev.hcl`
+4. `infra/scripts/workspace-init.sh`
+5. `infra/terraform/.gitignore` (update)
+
+### Implementation Steps:
+
+#### 1. Create workspace directory structure
+```bash
+mkdir -p infra/terraform/workspaces/{base,runtime}
+mkdir -p infra/terraform/backend-config
+mkdir -p infra/terraform/modules
+mkdir -p infra/terraform/shared
+```
+
+#### 2. Create backend configurations for workspaces
+```hcl
+# infra/terraform/backend-config/base-dev.hcl
+bucket         = "durable-code-terraform-state"
+key            = "base/dev/terraform.tfstate"
+region         = "us-west-2"
+encrypt        = true
+dynamodb_table = "terraform-state-lock"
+
+# infra/terraform/backend-config/runtime-dev.hcl
+bucket         = "durable-code-terraform-state"
+key            = "runtime/dev/terraform.tfstate"
+region         = "us-west-2"
+encrypt        = true
+dynamodb_table = "terraform-state-lock"
+```
+
+#### 3. Create workspace initialization script
+```bash
+#!/bin/bash
+# infra/scripts/workspace-init.sh
+
+WORKSPACE=$1
+ENV=$2
+
+if [[ -z "$WORKSPACE" || -z "$ENV" ]]; then
+  echo "Usage: ./workspace-init.sh [base|runtime] [dev|staging|prod]"
+  exit 1
+fi
+
+cd infra/terraform/workspaces/$WORKSPACE
+terraform init -backend-config="../../backend-config/${WORKSPACE}-${ENV}.hcl"
+terraform workspace new ${WORKSPACE}-${ENV} 2>/dev/null || terraform workspace select ${WORKSPACE}-${ENV}
+```
+
+#### 4. Update .gitignore
+```
+# Terraform workspaces
+*.tfstate
+*.tfstate.backup
+.terraform/
+infra/terraform/workspaces/*/.terraform/
+infra/terraform/workspaces/*/terraform.tfstate*
+```
+
+### Testing:
+```bash
+# Initialize base workspace
+./infra/scripts/workspace-init.sh base dev
+
+# Initialize runtime workspace
+./infra/scripts/workspace-init.sh runtime dev
+
+# Verify workspaces created
+terraform workspace list
+```
+
+---
+
+## PR2: Base Infrastructure Workspace
+
+### Branch: `feat/terraform-workspaces-pr2-base`
+
+### Files to Create/Modify:
+1. `infra/terraform/workspaces/base/main.tf`
+2. `infra/terraform/workspaces/base/variables.tf`
+3. `infra/terraform/workspaces/base/outputs.tf`
+4. `infra/terraform/workspaces/base/providers.tf`
+5. Move files: `networking.tf`, `ecr.tf`, `route53.tf`, `acm.tf`
+
+### Implementation Steps:
+
+#### 1. Create base workspace main configuration
+```hcl
+# infra/terraform/workspaces/base/main.tf
+
+terraform {
+  required_version = ">= 1.0"
+
+  backend "s3" {
+    # Configured via backend-config file
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  workspace_name = terraform.workspace
+  environment    = split("-", terraform.workspace)[1]
+
+  common_tags = {
+    Environment = local.environment
+    Workspace   = local.workspace_name
+    ManagedBy   = "Terraform"
+    Scope       = "base"
+  }
+}
+```
+
+#### 2. Move base resources from existing files
+```hcl
+# Move these resources to base/main.tf:
+# - aws_vpc
+# - aws_subnet (public and private)
+# - aws_internet_gateway
+# - aws_nat_gateway
+# - aws_eip
+# - aws_route_table
+# - aws_security_group (ALB and ECS)
+# - aws_ecr_repository
+# - aws_route53_zone
+# - aws_acm_certificate
+# - aws_lb (just the ALB itself, not targets/listeners)
+```
+
+#### 3. Create comprehensive outputs for runtime workspace
+```hcl
+# infra/terraform/workspaces/base/outputs.tf
+
+output "vpc_id" {
+  value       = aws_vpc.main.id
+  description = "VPC ID for runtime resources"
+}
+
+output "public_subnet_ids" {
+  value       = aws_subnet.public[*].id
+  description = "Public subnet IDs for ALB"
+}
+
+output "private_subnet_ids" {
+  value       = aws_subnet.private[*].id
+  description = "Private subnet IDs for ECS tasks"
+}
+
+output "alb_security_group_id" {
+  value       = aws_security_group.alb.id
+  description = "ALB security group ID"
+}
+
+output "ecs_tasks_security_group_id" {
+  value       = aws_security_group.ecs_tasks.id
+  description = "ECS tasks security group ID"
+}
+
+output "backend_ecr_repository_url" {
+  value       = aws_ecr_repository.backend.repository_url
+  description = "Backend ECR repository URL"
+}
+
+output "frontend_ecr_repository_url" {
+  value       = aws_ecr_repository.frontend.repository_url
+  description = "Frontend ECR repository URL"
+}
+
+output "alb_arn" {
+  value       = aws_lb.main.arn
+  description = "ALB ARN for target group attachment"
+}
+
+output "alb_dns_name" {
+  value       = aws_lb.main.dns_name
+  description = "ALB DNS name"
+}
+
+output "route53_zone_id" {
+  value       = aws_route53_zone.main.zone_id
+  description = "Route53 zone ID"
+}
+```
+
+### Testing:
+```bash
+# Deploy base infrastructure
+cd infra/terraform/workspaces/base
+terraform plan -var-file="../../environments/dev.tfvars"
+terraform apply -var-file="../../environments/dev.tfvars"
+```
+
+---
+
+## PR3: Runtime Infrastructure Workspace
+
+### Branch: `feat/terraform-workspaces-pr3-runtime`
+
+### Files to Create/Modify:
+1. `infra/terraform/workspaces/runtime/main.tf`
+2. `infra/terraform/workspaces/runtime/variables.tf`
+3. `infra/terraform/workspaces/runtime/outputs.tf`
+4. `infra/terraform/workspaces/runtime/providers.tf`
+5. Move files: Parts of `ecs.tf`, `alb.tf`
+
+### Implementation Steps:
+
+#### 1. Create runtime workspace main configuration
+```hcl
+# infra/terraform/workspaces/runtime/main.tf
+
+terraform {
+  required_version = ">= 1.0"
+
+  backend "s3" {
+    # Configured via backend-config file
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+locals {
+  workspace_name = terraform.workspace
+  environment    = split("-", terraform.workspace)[1]
+
+  common_tags = {
+    Environment = local.environment
+    Workspace   = local.workspace_name
+    ManagedBy   = "Terraform"
+    Scope       = "runtime"
+  }
+}
+```
+
+#### 2. Move runtime resources
+```hcl
+# Move these resources to runtime/main.tf:
+# - aws_ecs_cluster
+# - aws_ecs_task_definition
+# - aws_ecs_service
+# - aws_lb_target_group
+# - aws_lb_listener
+# - aws_lb_listener_rule
+# - aws_service_discovery_*
+# - aws_cloudwatch_log_group
+# - aws_iam_role (ECS specific)
+```
+
+### Testing:
+```bash
+# Deploy runtime infrastructure
+cd infra/terraform/workspaces/runtime
+terraform plan -var-file="../../environments/dev.tfvars"
+terraform apply -var-file="../../environments/dev.tfvars"
+
+# Test destroy
+terraform destroy -var-file="../../environments/dev.tfvars"
+```
+
+---
+
+## PR4: Data Sources and Cross-Workspace References
+
+### Branch: `feat/terraform-workspaces-pr4-data-sources`
+
+### Files to Create/Modify:
+1. `infra/terraform/workspaces/runtime/data.tf`
+2. `infra/terraform/workspaces/runtime/main.tf` (update references)
+3. `infra/terraform/modules/base-lookup/main.tf` (optional module)
+
+### Implementation Steps:
+
+#### 1. Create comprehensive data sources
+```hcl
+# infra/terraform/workspaces/runtime/data.tf
+
+# VPC lookup
+data "aws_vpc" "main" {
+  filter {
+    name   = "tag:Environment"
+    values = [local.environment]
+  }
+
+  filter {
+    name   = "tag:Scope"
+    values = ["base"]
+  }
+}
+
+# Subnet lookups
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+
+  filter {
+    name   = "tag:Type"
+    values = ["public"]
+  }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+
+  filter {
+    name   = "tag:Type"
+    values = ["private"]
+  }
+}
+
+# Security group lookups
+data "aws_security_group" "alb" {
+  filter {
+    name   = "tag:Name"
+    values = ["${var.project_name}-${local.environment}-alb-sg"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+}
+
+data "aws_security_group" "ecs_tasks" {
+  filter {
+    name   = "tag:Name"
+    values = ["${var.project_name}-${local.environment}-ecs-tasks-sg"]
+  }
+
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+}
+
+# ECR repository lookups
+data "aws_ecr_repository" "backend" {
+  name = "${var.product_domain}-${local.environment}-backend"
+}
+
+data "aws_ecr_repository" "frontend" {
+  name = "${var.product_domain}-${local.environment}-frontend"
+}
+
+# ALB lookup
+data "aws_lb" "main" {
+  name = "${var.project_name}-${local.environment}-alb"
+}
+
+# Route53 zone lookup
+data "aws_route53_zone" "main" {
+  name = var.domain_name
+}
+```
+
+#### 2. Update all references in runtime resources
+```hcl
+# Example updates in runtime/main.tf
+
+resource "aws_lb_target_group" "frontend" {
+  vpc_id = data.aws_vpc.main.id  # Instead of aws_vpc.main[0].id
+  # ...
+}
+
+resource "aws_ecs_service" "frontend" {
+  network_configuration {
+    subnets         = data.aws_subnets.private.ids
+    security_groups = [data.aws_security_group.ecs_tasks.id]
+  }
+  # ...
+}
+```
+
+### Testing:
+```bash
+# Verify data sources work
+cd infra/terraform/workspaces/runtime
+terraform plan -var-file="../../environments/dev.tfvars"
+
+# Should show no errors about missing resources
+```
+
+---
+
+## PR5: Makefile Integration and Commands
+
+### Branch: `feat/terraform-workspaces-pr5-makefile`
+
+### Files to Modify:
+1. `Makefile.infra`
+2. `infra/scripts/workspace-deploy.sh`
+3. `infra/scripts/workspace-destroy.sh`
+4. `infra/scripts/workspace-status.sh`
+
+### Implementation Steps:
+
+#### 1. Update Makefile.infra with workspace commands
+```makefile
+# Workspace management targets
+.PHONY: infra-workspace-init-base infra-workspace-init-runtime
+
+infra-workspace-init-base: ## Initialize base infrastructure workspace
+	@echo "$(CYAN)Initializing base workspace for $(ENV)...$(NC)"
+	@./infra/scripts/workspace-init.sh base $(ENV)
+	@echo "$(GREEN)✓ Base workspace initialized$(NC)"
+
+infra-workspace-init-runtime: ## Initialize runtime infrastructure workspace
+	@echo "$(CYAN)Initializing runtime workspace for $(ENV)...$(NC)"
+	@./infra/scripts/workspace-init.sh runtime $(ENV)
+	@echo "$(GREEN)✓ Runtime workspace initialized$(NC)"
+
+infra-up-base: infra-workspace-init-base ## Deploy base infrastructure
+	@echo "$(CYAN)Deploying base infrastructure...$(NC)"
+	@cd infra/terraform/workspaces/base && \
+		terraform apply -var-file="../../environments/$(ENV).tfvars" $(TF_ARGS)
+	@echo "$(GREEN)✓ Base infrastructure deployed$(NC)"
+
+infra-up-runtime: infra-workspace-init-runtime ## Deploy runtime infrastructure
+	@echo "$(CYAN)Deploying runtime infrastructure...$(NC)"
+	@cd infra/terraform/workspaces/runtime && \
+		terraform apply -var-file="../../environments/$(ENV).tfvars" $(TF_ARGS)
+	@echo "$(GREEN)✓ Runtime infrastructure deployed$(NC)"
+
+infra-down-runtime: infra-workspace-init-runtime ## Destroy runtime infrastructure
+	@echo "$(RED)Destroying runtime infrastructure...$(NC)"
+	@cd infra/terraform/workspaces/runtime && \
+		terraform destroy -var-file="../../environments/$(ENV).tfvars" $(TF_ARGS)
+	@echo "$(GREEN)✓ Runtime infrastructure destroyed$(NC)"
+
+infra-down-base: infra-workspace-init-base ## Destroy base infrastructure (DANGEROUS)
+	@if [ "$(CONFIRM)" != "destroy-base" ]; then \
+		echo "$(RED)ERROR: Base destruction requires CONFIRM=destroy-base$(NC)"; \
+		exit 1; \
+	fi
+	@cd infra/terraform/workspaces/base && \
+		terraform destroy -var-file="../../environments/$(ENV).tfvars" $(TF_ARGS)
+	@echo "$(GREEN)✓ Base infrastructure destroyed$(NC)"
+
+infra-status: ## Show workspace status
+	@./infra/scripts/workspace-status.sh $(ENV)
+```
+
+#### 2. Create workspace status script
+```bash
+#!/bin/bash
+# infra/scripts/workspace-status.sh
+
+ENV=$1
+
+echo "=== Terraform Workspace Status for $ENV ==="
+echo ""
+
+echo "Base Workspace (base-$ENV):"
+cd infra/terraform/workspaces/base
+terraform workspace select base-$ENV 2>/dev/null
+terraform output -json | jq -r 'keys[]' | head -5
+echo ""
+
+echo "Runtime Workspace (runtime-$ENV):"
+cd ../runtime
+terraform workspace select runtime-$ENV 2>/dev/null
+terraform output -json | jq -r 'keys[]' | head -5
+```
+
+### Testing:
+```bash
+# Test new commands
+make infra-up-base ENV=dev
+make infra-up-runtime ENV=dev
+make infra-status ENV=dev
+make infra-down-runtime ENV=dev
+# Verify base still exists
+make infra-status ENV=dev
+```
+
+---
+
+## PR6: Documentation and Testing
+
+### Branch: `feat/terraform-workspaces-pr6-docs`
+
+### Files to Create/Modify:
+1. `infra/terraform/WORKSPACES.md`
+2. `infra/terraform/MIGRATION.md`
+3. `infra/terraform/RUNBOOK.md`
+4. `infra/terraform/TROUBLESHOOTING.md`
+5. `infra/terraform/README.md` (update)
+6. `.github/workflows/terraform-test.yml`
+
+### Implementation Steps:
+
+#### 1. Create comprehensive workspace documentation
+```markdown
+# infra/terraform/WORKSPACES.md
+
+## Terraform Workspace Architecture
+
+### Overview
+We use Terraform workspaces to separate base (persistent) and runtime (ephemeral) infrastructure.
+
+### Workspace Structure
+- **base-{env}**: VPC, NAT, ECR, Route53 - rarely changed
+- **runtime-{env}**: ECS, ALB listeners - frequently updated
+
+### Common Operations
+
+#### Deploy everything
+```bash
+make infra-up-base ENV=dev
+make infra-up-runtime ENV=dev
+```
+
+#### Nightly shutdown
+```bash
+make infra-down-runtime ENV=dev
+```
+
+#### Morning startup
+```bash
+make infra-up-runtime ENV=dev
+```
+```
+
+#### 2. Create migration guide
+```markdown
+# infra/terraform/MIGRATION.md
+
+## Migration from Single State to Workspaces
+
+### Prerequisites
+1. Backup current state
+2. No pending changes
+3. Maintenance window scheduled
+
+### Migration Steps
+
+#### Step 1: Export current state
+```bash
+terraform state pull > backup.tfstate
+```
+
+#### Step 2: Import to base workspace
+```bash
+cd infra/terraform/workspaces/base
+terraform import aws_vpc.main vpc-xxx
+terraform import aws_subnet.public[0] subnet-xxx
+# ... continue for all base resources
+```
+
+#### Step 3: Import to runtime workspace
+```bash
+cd infra/terraform/workspaces/runtime
+terraform import aws_ecs_cluster.main arn:aws:ecs:xxx
+# ... continue for all runtime resources
+```
+
+#### Step 4: Verify
+```bash
+make infra-status ENV=dev
+```
+```
+
+#### 3. Create operational runbook
+```markdown
+# infra/terraform/RUNBOOK.md
+
+## Operational Runbook
+
+### Daily Operations
+
+#### Morning Startup (8 AM)
+```bash
+make infra-up-runtime ENV=dev
+make infra-status ENV=dev
+```
+
+#### Evening Shutdown (8 PM)
+```bash
+make infra-down-runtime ENV=dev
+```
+
+### Deployment Operations
+
+#### Deploy Code Changes
+```bash
+# Only affects runtime workspace
+make deploy ENV=dev
+```
+
+#### Infrastructure Updates
+```bash
+# Base changes (rare)
+make infra-up-base ENV=dev
+
+# Runtime changes (common)
+make infra-up-runtime ENV=dev
+```
+
+### Emergency Procedures
+
+#### Full Recovery
+```bash
+make infra-up-base ENV=dev
+make infra-up-runtime ENV=dev
+make deploy ENV=dev
+```
+```
+
+#### 4. Create troubleshooting guide
+```markdown
+# infra/terraform/TROUBLESHOOTING.md
+
+## Common Issues and Solutions
+
+### Issue: "No matching VPC found"
+**Cause**: Runtime workspace can't find base resources
+**Solution**:
+1. Verify base workspace deployed: `make infra-status ENV=dev`
+2. Check tags on base resources
+3. Redeploy base if needed: `make infra-up-base ENV=dev`
+
+### Issue: "Backend initialization failed"
+**Cause**: S3 backend not accessible
+**Solution**:
+1. Check AWS credentials
+2. Verify S3 bucket exists
+3. Check backend config file
+
+### Issue: "Workspace already exists"
+**Cause**: Trying to create existing workspace
+**Solution**: Use `terraform workspace select` instead
+```
+
+#### 5. Add CI/CD tests
+```yaml
+# .github/workflows/terraform-test.yml
+
+name: Terraform Workspace Tests
+
+on:
+  pull_request:
+    paths:
+      - 'infra/terraform/**'
+
+jobs:
+  test-workspaces:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+
+      - name: Test Base Workspace Init
+        run: |
+          cd infra/terraform/workspaces/base
+          terraform init -backend=false
+          terraform validate
+
+      - name: Test Runtime Workspace Init
+        run: |
+          cd infra/terraform/workspaces/runtime
+          terraform init -backend=false
+          terraform validate
+
+      - name: Check Workspace Dependencies
+        run: |
+          ./infra/scripts/check-workspace-deps.sh
+```
+
+### Testing:
+```bash
+# Full integration test
+make infra-up-base ENV=dev
+make infra-up-runtime ENV=dev
+make infra-down-runtime ENV=dev
+make infra-up-runtime ENV=dev
+make infra-status ENV=dev
+
+# Verify documentation
+grep -r "workspace" infra/terraform/*.md
+```
+
+---
+
+## Success Criteria Checklist
+
+After all PRs are complete, verify:
+
+- [ ] Base and runtime in separate workspaces
+- [ ] Each workspace has independent state
+- [ ] Runtime references base via data sources
+- [ ] `make infra-down-runtime` works without errors
+- [ ] `make infra-up-runtime` restores service
+- [ ] Base resources unchanged during runtime operations
+- [ ] All Makefile commands updated
+- [ ] Documentation complete
+- [ ] Migration guide tested
+- [ ] CI/CD pipeline updated
+- [ ] Cost optimization verified
+
+## Rollback Plan
+
+If issues arise during implementation:
+
+1. **Stop all changes immediately**
+2. **Restore from backup**: `terraform state push backup.tfstate`
+3. **Revert code changes**: `git revert HEAD~n`
+4. **Verify infrastructure intact**: `terraform plan`
+5. **Document lessons learned**
+6. **Re-plan approach**
+
+---
+**Remember**: Each PR should be atomic and leave the infrastructure in a working state. Test thoroughly in dev before proceeding to the next PR.


### PR DESCRIPTION
## Summary
- Create comprehensive roadmap for implementing Terraform workspaces
- Addresses issue with scope-based infrastructure destruction  
- Plans separation of base (persistent) and runtime (ephemeral) resources

## Problem Being Solved
The current Terraform infrastructure uses conditional `count` logic causing "empty tuple" errors when trying to destroy only runtime resources with `make infra-down SCOPE=runtime`.

## Solution Approach
Implement Terraform workspaces to cleanly separate:
- **Base Workspace**: VPC, NAT Gateways, ECR repositories, Route53 zones
- **Runtime Workspace**: ECS services, ALB listeners, target groups
- **Data Sources**: Runtime workspace references base resources via data lookups

## Roadmap Structure
Created 6 PRs for complete implementation:
- PR1: Workspace foundation and backend configuration
- PR2: Base infrastructure workspace isolation
- PR3: Runtime infrastructure workspace isolation  
- PR4: Data sources for cross-workspace references
- PR5: Makefile integration and commands
- PR6: Documentation and testing

## Documentation Created
- `PROGRESS_TRACKER.md` - Primary handoff document (0% complete)
- `AI_CONTEXT.md` - Background and architectural decisions
- `PR_BREAKDOWN.md` - Detailed implementation steps
- Updated master `ROADMAP.md` with new planning item

## Benefits
- ✅ Fixes "empty tuple" errors permanently
- ✅ Enables cost optimization through selective destruction
- ✅ Clean separation of concerns
- ✅ Harder to accidentally destroy base infrastructure
- ✅ Independent state management

## Test Plan
- [x] Roadmap documentation created
- [x] All templates properly filled
- [x] Master roadmap updated
- [ ] Ready for implementation when prioritized

🤖 Generated with Claude Code