### PR TITLE
feat(ci): Deactivate build-and-push workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -13,21 +13,24 @@
 
 name: Build and Push to ECR
 
-on:
-  push:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'durable-code-app/**'
-      - 'Dockerfile*'
-  pull_request:
-    branches:
-      - main
-      - develop
-    paths:
-      - 'durable-code-app/**'
-      - 'Dockerfile*'
+# Workflow temporarily deactivated - not currently in use
+# To re-enable, uncomment the 'on:' section below
+on: workflow_dispatch
+# on:
+#   push:
+#     branches:
+#       - main
+#       - develop
+#     paths:
+#       - 'durable-code-app/**'
+#       - 'Dockerfile*'
+#   pull_request:
+#     branches:
+#       - main
+#       - develop
+#     paths:
+#       - 'durable-code-app/**'
+#       - 'Dockerfile*'
 
 env:
   AWS_REGION: us-west-2


### PR DESCRIPTION
## Summary
- Temporarily deactivate the build-and-push workflow as it's not currently in use
- Changed trigger from automatic (push/PR events) to manual only (workflow_dispatch)
- Preserved original configuration as comments for easy re-enablement

## Changes Made
- 🔧 Modified `.github/workflows/build-and-push.yml` to use `workflow_dispatch` trigger
- 💬 Added clear comments explaining the deactivation
- 📝 Preserved original trigger configuration as comments
- ♻️ Workflow can still be manually triggered from GitHub Actions UI if needed

## Test Plan
- [x] Verified workflow file syntax is valid
- [x] Confirmed commit was created successfully
- [x] Pre-commit hooks passed (linting, formatting)
- [x] Branch pushed to remote successfully

## Quality Assurance
- [x] All linters pass
- [x] Pre-commit hooks pass
- [x] No functional code changes (workflow configuration only)
- [x] Documentation added via comments in workflow file

## Breaking Changes
None - this only affects CI/CD workflow triggers. The workflow can still be manually triggered if needed.

## Deployment Notes
- Workflow will no longer run automatically on pushes to main/develop
- Workflow will no longer run automatically on PRs to main/develop
- Can be manually triggered via GitHub Actions UI: Actions → Build and Push to ECR → Run workflow
- To re-enable automatic triggers, uncomment the `on:` section in the workflow file

🤖 Generated with [Claude Code](https://claude.com/claude-code)