### PR TITLE
fix: Update infrastructure workflows to use OIDC authentication

### DIFF
--- a/.github/workflows/morning-startup.yml
+++ b/.github/workflows/morning-startup.yml
@@ -38,6 +38,7 @@ jobs:
   startup:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
       actions: read
 
@@ -51,8 +52,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: GitHub-Actions-Startup-${{ github.run_id }}
           aws-region: us-west-2
 
       - name: Verify AWS credentials

--- a/.github/workflows/nightly-teardown.yml
+++ b/.github/workflows/nightly-teardown.yml
@@ -33,6 +33,7 @@ jobs:
   teardown:
     runs-on: ubuntu-latest
     permissions:
+      id-token: write
       contents: read
       actions: read
 
@@ -46,8 +47,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: GitHub-Actions-Teardown-${{ github.run_id }}
           aws-region: us-west-2
 
       - name: Verify AWS credentials


### PR DESCRIPTION
## Summary
- Fix authentication failures in nightly-teardown and morning-startup workflows
- Replace deprecated AWS access key authentication with OIDC role assumption
- Both workflows now use the existing AWS_ROLE_ARN secret

## Problem
Both workflows were failing with "Credentials could not be loaded" because they were trying to use AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secrets that don't exist in the repository. The repository only has AWS_ROLE_ARN configured.

## Solution
- Added `id-token: write` permission for OIDC authentication
- Replaced `aws-access-key-id` and `aws-secret-access-key` with `role-to-assume`
- Now uses `${{ secrets.AWS_ROLE_ARN }}` which is already configured

## Testing
Need to trigger both workflows after merge to verify they work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)