### PR TITLE
fix: Correct make targets and add AUTO flag for CI workflows

### DIFF
--- a/.github/workflows/morning-startup.yml
+++ b/.github/workflows/morning-startup.yml
@@ -81,7 +81,7 @@ jobs:
           SCOPE="${{ inputs.scope || 'runtime' }}"
 
           echo "⏰ Infrastructure startup initiated at $(date)"
-          make infra-up SCOPE="$SCOPE" ENV="$ENV"
+          make infra-up SCOPE="$SCOPE" ENV="$ENV" AUTO=true
 
       - name: Wait for infrastructure readiness
         if: ${{ inputs.dry_run != true }}

--- a/.github/workflows/nightly-teardown.yml
+++ b/.github/workflows/nightly-teardown.yml
@@ -66,7 +66,9 @@ jobs:
         if: ${{ inputs.dry_run == true }}
         run: |
           echo "🔍 Planning infrastructure teardown (dry run)..."
-          make infra-plan-destroy SCOPE=${{ inputs.scope || 'runtime' }} ENV=${{ inputs.environment || 'dev' }}
+          echo "Note: Terraform destroy does not support separate plan output."
+          echo "Showing current state instead:"
+          make infra-status ENV=${{ inputs.environment || 'dev' }}
 
       - name: Execute infrastructure teardown
         if: ${{ inputs.dry_run != true }}
@@ -76,12 +78,15 @@ jobs:
           SCOPE="${{ inputs.scope || 'runtime' }}"
 
           # Add confirmation for base/all scope destruction
-          if [[ "$SCOPE" == "all" ]] || [[ "$SCOPE" == "base" ]]; then
-            echo "⚠️ Destroying base infrastructure requires confirmation"
-            export CONFIRM=destroy-base
+          if [[ "$SCOPE" == "all" ]]; then
+            echo "⚠️ Destroying all infrastructure"
+            make infra-down SCOPE="$SCOPE" ENV="$ENV" AUTO=true CONFIRM=destroy-all
+          elif [[ "$SCOPE" == "base" ]]; then
+            echo "⚠️ Destroying base infrastructure"
+            make infra-down SCOPE="$SCOPE" ENV="$ENV" AUTO=true CONFIRM=destroy-base
+          else
+            make infra-down SCOPE="$SCOPE" ENV="$ENV" AUTO=true
           fi
-
-          make infra-down SCOPE="$SCOPE" ENV="$ENV"
 
       - name: Check infrastructure status (after)
         if: ${{ inputs.dry_run != true }}


### PR DESCRIPTION
## Summary
- Fix infrastructure workflows to use correct make targets
- Enable non-interactive mode for CI execution with AUTO=true flag
- Fix dry run behavior for teardown workflow

## Problem
The workflows were using invalid make targets and not running in non-interactive mode, causing failures in CI.

## Changes

### nightly-teardown.yml
- Replace non-existent `infra-plan-destroy` with `infra-status` for dry runs
- Add `AUTO=true` flag for non-interactive terraform destroy
- Add proper `CONFIRM` flags for base/all scope destruction

### morning-startup.yml
- Add `AUTO=true` flag for non-interactive terraform apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)