### PR TITLE
fix: Remove AWS_PROFILE dependency in CI workflows

### DIFF
--- a/.github/workflows/morning-startup.yml
+++ b/.github/workflows/morning-startup.yml
@@ -65,13 +65,13 @@ jobs:
       - name: Check infrastructure status (before)
         run: |
           echo "📊 Infrastructure status before startup:"
-          make infra-status ENV=${{ inputs.environment || 'dev' }} || echo "Status check completed"
+          make infra-status ENV=${{ inputs.environment || 'dev' }} AWS_PROFILE="" || echo "Status check completed"
 
       - name: Plan infrastructure startup
         if: ${{ inputs.dry_run == true }}
         run: |
           echo "🔍 Planning infrastructure startup (dry run)..."
-          make infra-plan SCOPE=${{ inputs.scope || 'runtime' }} ENV=${{ inputs.environment || 'dev' }}
+          make infra-plan SCOPE=${{ inputs.scope || 'runtime' }} ENV=${{ inputs.environment || 'dev' }} AWS_PROFILE=""
 
       - name: Execute infrastructure startup
         if: ${{ inputs.dry_run != true }}
@@ -81,7 +81,8 @@ jobs:
           SCOPE="${{ inputs.scope || 'runtime' }}"
 
           echo "⏰ Infrastructure startup initiated at $(date)"
-          make infra-up SCOPE="$SCOPE" ENV="$ENV" AUTO=true
+          # In CI, don't use AWS_PROFILE - OIDC sets environment variables directly
+          make infra-up SCOPE="$SCOPE" ENV="$ENV" AUTO=true AWS_PROFILE=""
 
       - name: Wait for infrastructure readiness
         if: ${{ inputs.dry_run != true }}
@@ -92,7 +93,7 @@ jobs:
           # Wait up to 10 minutes for infrastructure to be ready
           for i in {1..30}; do
             echo "  Attempt $i/30: Checking infrastructure readiness..."
-            if make infra-check ENV="$ENV" 2>/dev/null; then
+            if make infra-check ENV="$ENV" AWS_PROFILE="" 2>/dev/null; then
               echo "✅ Infrastructure is ready!"
               break
             fi
@@ -100,7 +101,7 @@ jobs:
             if [[ $i -eq 30 ]]; then
               echo "⚠️ Infrastructure readiness timeout after 10 minutes"
               echo "📊 Current status:"
-              make infra-status ENV="$ENV" || true
+              make infra-status ENV="$ENV" AWS_PROFILE="" || true
               exit 1
             fi
 
@@ -114,7 +115,7 @@ jobs:
           ENV="${{ inputs.environment || 'dev' }}"
 
           echo "📦 Starting application deployment..."
-          make deploy ENV="$ENV"
+          make deploy ENV="$ENV" AWS_PROFILE=""
 
       - name: Verify application health
         if: ${{ inputs.deploy_app == true && inputs.dry_run != true }}
@@ -127,7 +128,7 @@ jobs:
             echo "  Health check attempt $i/15..."
 
             # Get ALB DNS name from infrastructure status
-            ALB_DNS=$(make infra-output ENV="$ENV" | grep alb_dns_name | cut -d'"' -f4 || echo "")
+            ALB_DNS=$(make infra-output ENV="$ENV" AWS_PROFILE="" | grep alb_dns_name | cut -d'"' -f4 || echo "")
 
             if [[ -n "$ALB_DNS" ]]; then
               if curl -f --max-time 10 "http://$ALB_DNS/health" >/dev/null 2>&1; then
@@ -148,7 +149,7 @@ jobs:
         if: ${{ inputs.dry_run != true }}
         run: |
           echo "📊 Final infrastructure status:"
-          make infra-status ENV=${{ inputs.environment || 'dev' }} || echo "Status check completed"
+          make infra-status ENV=${{ inputs.environment || 'dev' }} AWS_PROFILE="" || echo "Status check completed"
 
       - name: Post startup summary
         if: always()
@@ -163,7 +164,7 @@ jobs:
 
           ENV="${{ inputs.environment || 'dev' }}"
           if [[ "${{ job.status }}" == "success" && "${{ inputs.dry_run }}" != "true" ]]; then
-            ALB_DNS=$(make infra-output ENV="$ENV" | grep alb_dns_name | cut -d'"' -f4 || echo "")
+            ALB_DNS=$(make infra-output ENV="$ENV" AWS_PROFILE="" | grep alb_dns_name | cut -d'"' -f4 || echo "")
             if [[ -n "$ALB_DNS" ]]; then
               echo "🌐 Application URLs:"
               echo "  - Frontend: http://$ALB_DNS"

--- a/.github/workflows/nightly-teardown.yml
+++ b/.github/workflows/nightly-teardown.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Check infrastructure status (before)
         run: |
           echo "📊 Infrastructure status before teardown:"
-          make infra-status ENV=${{ inputs.environment || 'dev' }} || echo "Status check failed - continuing with teardown"
+          make infra-status ENV=${{ inputs.environment || 'dev' }} AWS_PROFILE="" || echo "Status check failed - continuing with teardown"
 
       - name: Plan infrastructure teardown
         if: ${{ inputs.dry_run == true }}
@@ -68,7 +68,7 @@ jobs:
           echo "🔍 Planning infrastructure teardown (dry run)..."
           echo "Note: Terraform destroy does not support separate plan output."
           echo "Showing current state instead:"
-          make infra-status ENV=${{ inputs.environment || 'dev' }}
+          make infra-status ENV=${{ inputs.environment || 'dev' }} AWS_PROFILE=""
 
       - name: Execute infrastructure teardown
         if: ${{ inputs.dry_run != true }}
@@ -77,22 +77,23 @@ jobs:
           ENV="${{ inputs.environment || 'dev' }}"
           SCOPE="${{ inputs.scope || 'runtime' }}"
 
+          # In CI, don't use AWS_PROFILE - OIDC sets environment variables directly
           # Add confirmation for base/all scope destruction
           if [[ "$SCOPE" == "all" ]]; then
             echo "⚠️ Destroying all infrastructure"
-            make infra-down SCOPE="$SCOPE" ENV="$ENV" AUTO=true CONFIRM=destroy-all
+            make infra-down SCOPE="$SCOPE" ENV="$ENV" AUTO=true CONFIRM=destroy-all AWS_PROFILE=""
           elif [[ "$SCOPE" == "base" ]]; then
             echo "⚠️ Destroying base infrastructure"
-            make infra-down SCOPE="$SCOPE" ENV="$ENV" AUTO=true CONFIRM=destroy-base
+            make infra-down SCOPE="$SCOPE" ENV="$ENV" AUTO=true CONFIRM=destroy-base AWS_PROFILE=""
           else
-            make infra-down SCOPE="$SCOPE" ENV="$ENV" AUTO=true
+            make infra-down SCOPE="$SCOPE" ENV="$ENV" AUTO=true AWS_PROFILE=""
           fi
 
       - name: Check infrastructure status (after)
         if: ${{ inputs.dry_run != true }}
         run: |
           echo "📊 Infrastructure status after teardown:"
-          make infra-status ENV=${{ inputs.environment || 'dev' }} || echo "Status check completed"
+          make infra-status ENV=${{ inputs.environment || 'dev' }} AWS_PROFILE="" || echo "Status check completed"
 
       - name: Calculate cost savings
         if: ${{ inputs.dry_run != true }}


### PR DESCRIPTION
## Summary
- Remove AWS_PROFILE dependency in GitHub Actions workflows
- Allow OIDC-provided environment variables to be used directly

## Problem
Workflows were failing with "failed to get shared config profile, terraform-deploy" because they tried to use an AWS profile that doesn't exist in CI. OIDC authentication provides credentials as environment variables, not as a profile.

## Solution
Set `AWS_PROFILE=""` in all make commands to prevent Terraform from looking for a profile file and instead use the environment variables set by OIDC:
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY  
- AWS_SESSION_TOKEN

## Changes
Both workflows now pass `AWS_PROFILE=""` to all infrastructure make commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)