### PR TITLE
Add infrastructure destroy permissions to GitHub Actions role

### DIFF
--- a/infra/terraform/workspaces/base/github-oidc.tf
+++ b/infra/terraform/workspaces/base/github-oidc.tf
@@ -110,7 +110,9 @@ resource "aws_iam_role_policy" "github_actions_ecs" {
           "ecs:DescribeServices",
           "ecs:DescribeClusters",
           "ecs:ListTasks",
-          "ecs:DescribeTasks"
+          "ecs:DescribeTasks",
+          "ecs:DeleteService",
+          "ecs:PutClusterCapacityProviders"
         ]
         Resource = "*"
       },
@@ -214,6 +216,7 @@ resource "aws_iam_role_policy" "github_actions_infrastructure" {
           "ec2:Describe*",
           "ec2:CreateTags",
           "ec2:DeleteTags",
+          "ec2:DisassociateRouteTable",
           # ELB permissions
           "elasticloadbalancing:Describe*",
           "elasticloadbalancing:AddTags",
@@ -224,16 +227,19 @@ resource "aws_iam_role_policy" "github_actions_infrastructure" {
           "route53:GetChange",
           "route53:ListResourceRecordSets",
           "route53:ListTagsForResource",
+          "route53:ChangeResourceRecordSets",
           # ACM permissions
           "acm:ListCertificates",
           "acm:DescribeCertificate",
           "acm:GetCertificate",
           "acm:ListTagsForCertificate",
-          # IAM read permissions for roles
+          # IAM permissions for role and policy management
           "iam:GetRole",
           "iam:ListRolePolicies",
           "iam:GetRolePolicy",
-          "iam:ListAttachedRolePolicies"
+          "iam:ListAttachedRolePolicies",
+          "iam:DeleteRolePolicy",
+          "iam:DetachRolePolicy"
         ]
         Resource = "*"
       }


### PR DESCRIPTION
## Summary
- Add missing IAM permissions for nightly teardown workflow to successfully destroy infrastructure
- Fixes 403 AccessDenied errors during infrastructure teardown operations

## Changes
**ECS Permissions:**
- `ecs:DeleteService` - delete ECS services during teardown
- `ecs:PutClusterCapacityProviders` - modify cluster capacity providers

**EC2/VPC Permissions:**
- `ec2:DisassociateRouteTable` - disassociate route tables during VPC teardown

**Route53 Permissions:**
- `route53:ChangeResourceRecordSets` - modify/delete DNS records

**IAM Permissions:**
- `iam:DeleteRolePolicy` - delete inline IAM role policies
- `iam:DetachRolePolicy` - detach managed IAM policies from roles

## Test Plan
- [x] Applied terraform changes to dev environment
- [x] IAM permissions updated successfully
- [ ] Trigger nightly-teardown workflow to verify all permissions work

## Related
Fixes nightly teardown workflow failures from run 18182742028

🤖 Generated with [Claude Code](https://claude.com/claude-code)