### PR TITLE
fix: Add comprehensive IAM permissions for complete infrastructure lifecycle

### DIFF
--- a/infra/terraform/workspaces/bootstrap/github-oidc.tf
+++ b/infra/terraform/workspaces/bootstrap/github-oidc.tf
@@ -84,7 +84,20 @@ resource "aws_iam_role_policy" "github_actions_ecr" {
           "ecr:DescribeRepositories",
           "ecr:DescribeImages",
           "ecr:ListImages",
-          "ecr:ListTagsForResource"
+          "ecr:ListTagsForResource",
+          "ecr:CreateRepository",
+          "ecr:DeleteRepository",
+          "ecr:BatchDeleteImage",
+          "ecr:PutImageTagMutability",
+          "ecr:PutImageScanningConfiguration",
+          "ecr:PutEncryptionConfiguration",
+          "ecr:PutLifecyclePolicy",
+          "ecr:GetLifecyclePolicy",
+          "ecr:GetLifecyclePolicyPreview",
+          "ecr:DeleteLifecyclePolicy",
+          "ecr:SetRepositoryPolicy",
+          "ecr:GetRepositoryPolicy",
+          "ecr:DeleteRepositoryPolicy"
         ]
         Resource = "*"
       }
@@ -117,7 +130,12 @@ resource "aws_iam_role_policy" "github_actions_ecs" {
           "ecs:DescribeTasks",
           "ecs:PutClusterCapacityProviders",
           "ecs:TagResource",
-          "ecs:UntagResource"
+          "ecs:UntagResource",
+          "ecs:UpdateCluster",
+          "ecs:UpdateClusterSettings",
+          "ecs:ListTaskDefinitionFamilies",
+          "ecs:DeleteTaskDefinitions",
+          "ecs:UpdateServicePrimaryTaskSet"
         ]
         Resource = "*"
       },
@@ -155,7 +173,10 @@ resource "aws_iam_role_policy" "github_actions_logs" {
           "logs:DescribeLogGroups",
           "logs:ListTagsForResource",
           "logs:TagResource",
-          "logs:UntagResource"
+          "logs:UntagResource",
+          "logs:PutRetentionPolicy",
+          "logs:DeleteRetentionPolicy",
+          "logs:GetLogEvents"
         ]
         Resource = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:*"
       }
@@ -214,7 +235,11 @@ resource "aws_iam_role_policy" "github_actions_terraform_state" {
           "s3:DeleteObject",
           "s3:DeleteObjectVersion",
           "s3:GetObjectVersion",
-          "s3:ListBucketVersions"
+          "s3:ListBucketVersions",
+          "s3:GetAccelerateConfiguration",
+          "s3:GetBucketRequestPayment",
+          "s3:GetLifecycleConfiguration",
+          "s3:GetBucketPolicyStatus"
         ]
         Resource = [
           "arn:aws:s3:::${var.project_name}-*",
@@ -338,6 +363,9 @@ resource "aws_iam_role_policy" "github_actions_infrastructure" {
           "elasticloadbalancing:ModifyRule",
           "elasticloadbalancing:RegisterTargets",
           "elasticloadbalancing:DeregisterTargets",
+          "elasticloadbalancing:AddListenerCertificates",
+          "elasticloadbalancing:RemoveListenerCertificates",
+          "elasticloadbalancing:SetRulePriorities",
           # Route53 permissions
           "route53:GetHostedZone",
           "route53:ListHostedZones",
@@ -347,6 +375,10 @@ resource "aws_iam_role_policy" "github_actions_infrastructure" {
           "route53:ChangeResourceRecordSets",
           "route53:CreateHostedZone",
           "route53:DeleteHostedZone",
+          "route53:ListHostedZonesByName",
+          "route53:UpdateHostedZoneComment",
+          "route53:AssociateVPCWithHostedZone",
+          "route53:DisassociateVPCFromHostedZone",
           # ACM permissions
           "acm:ListCertificates",
           "acm:DescribeCertificate",
@@ -356,6 +388,9 @@ resource "aws_iam_role_policy" "github_actions_infrastructure" {
           "acm:DeleteCertificate",
           "acm:AddTagsToCertificate",
           "acm:RemoveTagsFromCertificate",
+          "acm:UpdateCertificateOptions",
+          "acm:RenewCertificate",
+          "acm:ResendValidationEmail",
           # IAM permissions for role and policy management
           "iam:GetRole",
           "iam:CreateRole",
@@ -370,7 +405,13 @@ resource "aws_iam_role_policy" "github_actions_infrastructure" {
           "iam:TagRole",
           "iam:UntagRole",
           "iam:UpdateAssumeRolePolicy",
-          "iam:ListInstanceProfilesForRole"
+          "iam:ListInstanceProfilesForRole",
+          "iam:UpdateRole",
+          "iam:UpdateRoleDescription",
+          "iam:ListRoles",
+          "iam:ListRoleTags",
+          "iam:PutRolePermissionsBoundary",
+          "iam:DeleteRolePermissionsBoundary"
         ]
         Resource = "*"
       }


### PR DESCRIPTION
## Summary
- Adds 39 missing IAM permissions to bootstrap GitHub Actions role based on comprehensive audit of all Terraform resources
- Fixes CloudWatch Logs `PutRetentionPolicy` permission error from morning startup job
- Ensures complete infrastructure lifecycle operations have proper permissions

## Changes by Service
- **ECR (13 permissions)**: Repository management, lifecycle policies, repository policies
- **ECS (5 permissions)**: Cluster updates, task definition management  
- **CloudWatch Logs (3 permissions)**: Retention policies, log events access
- **S3 (4 permissions)**: Additional bucket configuration queries
- **Route53 (4 permissions)**: VPC association, hosted zone management
- **ACM (3 permissions)**: Certificate lifecycle operations
- **ALB (3 permissions)**: Listener certificate management, rule priorities
- **IAM (6 permissions)**: Role updates, permissions boundaries

## Testing
- ✅ Terraform plan shows 5 policy updates
- ✅ Applied successfully to bootstrap workspace (0 added, 5 changed, 0 destroyed)
- ✅ All linting checks passed

## Root Cause Analysis
Performed complete inventory of 46 resource types across base and runtime workspaces, researched AWS documentation for required permissions, identified gaps in current policy, and added all missing permissions for full CRUD lifecycle support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)