### PR TITLE
fix: Resolve AWS credentials issue in GitHub Actions deployment

### DIFF
--- a/.github/workflows/morning-startup.yml
+++ b/.github/workflows/morning-startup.yml
@@ -115,7 +115,8 @@ jobs:
           ENV="${{ inputs.environment || 'dev' }}"
 
           echo "📦 Starting application deployment..."
-          make deploy ENV="$ENV" AWS_PROFILE=""
+          unset AWS_PROFILE
+          make deploy ENV="$ENV"
 
       - name: Verify application health
         if: ${{ inputs.deploy_app == true && inputs.dry_run != true }}


### PR DESCRIPTION
## Summary
- Fixed AWS credentials authentication failure in GitHub Actions morning-startup workflow

## Changes
- Changed `AWS_PROFILE=""` to `unset AWS_PROFILE` in the deployment step

## Root Cause
Setting `AWS_PROFILE=""` causes AWS CLI to search for a profile with an empty name, resulting in `The config profile () could not be found` error. The workflow uses OIDC authentication which sets environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`), but an empty `AWS_PROFILE` overrides this and tries to use the (non-existent) profile instead.

## Solution
Unsetting `AWS_PROFILE` entirely allows AWS CLI to fall back to using the OIDC-provided environment credentials as intended.

## Test Plan
- [ ] GitHub Actions workflow runs successfully
- [ ] Deployment completes without authentication errors
- [ ] Application deploys to ECS

🤖 Generated with [Claude Code](https://claude.com/claude-code)