### PR TITLE
fix: Unset AWS_PROFILE in deploy script when running in GitHub Actions

### DIFF
--- a/.github/workflows/morning-startup.yml
+++ b/.github/workflows/morning-startup.yml
@@ -115,7 +115,6 @@ jobs:
           ENV="${{ inputs.environment || 'dev' }}"
 
           echo "📦 Starting application deployment..."
-          unset AWS_PROFILE
           make deploy ENV="$ENV"
 
       - name: Verify application health

--- a/infra/scripts/deploy-app.sh
+++ b/infra/scripts/deploy-app.sh
@@ -37,6 +37,8 @@ echo "Build Timestamp: ${BUILD_TIMESTAMP}"
 echo "Logging into ECR..."
 if [ -n "${GITHUB_ACTIONS}" ]; then
   # Running in GitHub Actions - use OIDC credentials from environment
+  # Unset AWS_PROFILE to prevent it from overriding OIDC credentials
+  unset AWS_PROFILE
   echo "Using AWS credentials from GitHub Actions OIDC"
   aws ecr get-login-password --region "${AWS_REGION}" | docker login --username AWS --password-stdin "${ECR_REGISTRY}"
 elif [ -n "${AWS_PROFILE}" ]; then


### PR DESCRIPTION
## Summary
- Fixed AWS credentials authentication by unsetting AWS_PROFILE inside the deployment script when running in GitHub Actions

## Root Cause
The deployment script checks if `AWS_PROFILE` is set and uses it even when running in GitHub Actions. The Makefile was passing through `AWS_PROFILE=terraform-deploy` from the environment, causing the AWS CLI to look for a profile instead of using OIDC credentials.

## Solution
When `GITHUB_ACTIONS` is detected, the script now explicitly unsets `AWS_PROFILE` before calling AWS CLI commands, ensuring OIDC environment credentials are used.

## Test Plan
- [ ] GitHub Actions morning-startup workflow runs successfully
- [ ] Deployment authenticates with ECR using OIDC
- [ ] Application deploys to ECS without profile errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)