### PR TITLE
fix: Update health check to use correct API endpoint and reduce timeout

### DIFF
--- a/.github/workflows/morning-startup.yml
+++ b/.github/workflows/morning-startup.yml
@@ -123,23 +123,31 @@ jobs:
           echo "🏥 Verifying application health..."
           ENV="${{ inputs.environment || 'dev' }}"
 
-          # Wait up to 5 minutes for application to be healthy
-          for i in {1..15}; do
-            echo "  Health check attempt $i/15..."
+          # Get ALB DNS name from infrastructure status
+          ALB_DNS=$(make infra-output ENV="$ENV" AWS_PROFILE="" | grep alb_dns_name | cut -d'"' -f4 || echo "")
 
-            # Get ALB DNS name from infrastructure status
-            ALB_DNS=$(make infra-output ENV="$ENV" AWS_PROFILE="" | grep alb_dns_name | cut -d'"' -f4 || echo "")
+          if [[ -z "$ALB_DNS" ]]; then
+            echo "⚠️ Could not retrieve ALB DNS name"
+            echo "📊 Skipping health check - check ECS console for deployment status"
+            exit 0
+          fi
 
-            if [[ -n "$ALB_DNS" ]]; then
-              if curl -f --max-time 10 "http://$ALB_DNS/health" >/dev/null 2>&1; then
-                echo "✅ Application is healthy!"
-                break
-              fi
+          echo "📍 ALB DNS: $ALB_DNS"
+          echo "🔍 Testing backend health endpoint: http://$ALB_DNS/api/health"
+
+          # Wait up to 3 minutes for application to be healthy
+          for i in {1..9}; do
+            echo "  Health check attempt $i/9..."
+
+            if curl -f --max-time 10 "http://$ALB_DNS/api/health" >/dev/null 2>&1; then
+              echo "✅ Application is healthy!"
+              exit 0
             fi
 
-            if [[ $i -eq 15 ]]; then
-              echo "⚠️ Application health check timeout after 5 minutes"
+            if [[ $i -eq 9 ]]; then
+              echo "⚠️ Application health check timeout after 3 minutes"
               echo "📊 This is normal for first startup - application may still be initializing"
+              echo "💡 Check ECS service status for deployment progress"
             fi
 
             sleep 20


### PR DESCRIPTION
## Summary
- Fixed health check endpoint from `/health` to `/api/health`
- Reduced timeout from 5 minutes to 3 minutes
- Added better debugging output

## Root Cause
The workflow was checking `/health` but the ALB routes the backend to `/api/*` paths only. This caused health checks to always fail and timeout after 5 minutes.

## Changes
- Changed health check URL to `/api/health` (correct ALB routing)
- Reduced wait time from 15 iterations (5min) to 9 iterations (3min)
- Added ALB DNS output for debugging
- Made timeout exit gracefully with informative message

## Test Plan
- [ ] Verify health check succeeds when backend is healthy
- [ ] Verify timeout doesn't fail the workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)